### PR TITLE
Fix columns not being found from index defintion

### DIFF
--- a/libraries/cms/schema/changeitem/mysql.php
+++ b/libraries/cms/schema/changeitem/mysql.php
@@ -535,7 +535,7 @@ class JSchemaChangeitemMysql extends JSchemaChangeitem
 		$tmpStr = $wordArray[$idxListStart];
 		if ($removeFirstBracket)
 		{
-			$tmpStr = substr($tmpStr, 0, $firstBracketPos + 1);
+			$tmpStr = substr($tmpStr, $firstBracketPos + 1, strlen($tmpStr));
 		}
 		$tmpStr = str_replace(' ', '', $tmpStr);
 		$tmpStr = str_replace('`', '', $tmpStr);


### PR DESCRIPTION
This doesn't fix everything - but makes a start. So the `GROUP_CONCAT` is screwing things up here. If I remove the group concat then single column index's start to work (but obviously the multi-column index's do not)