### PR TITLE
Need to check database connection on global configuration save

### DIFF
--- a/administrator/components/com_config/Model/ApplicationModel.php
+++ b/administrator/components/com_config/Model/ApplicationModel.php
@@ -130,8 +130,26 @@ class ApplicationModel extends FormModel
 			'user'     => $data['user'],
 			'password' => $app->get('password'),
 			'database' => $data['db'],
-			'prefix'   => $data['dbprefix']
+			'prefix'   => $data['dbprefix'],
 		);
+
+		if ((int) $data['dbencryption'] !== 0)
+		{
+			$options['ssl'] = [
+				'enable'             => true,
+				'verify_server_cert' => (bool) $data['dbsslverifyservercert'],
+			];
+
+			foreach (['cipher', 'ca', 'capath', 'key', 'cert'] as $value)
+			{
+				$confVal = trim($data['dbssl' . $value]);
+
+				if ($confVal !== '')
+				{
+					$options['ssl'][$value] = $confVal;
+				}
+			}
+		}
 
 		try
 		{

--- a/administrator/components/com_config/Model/ApplicationModel.php
+++ b/administrator/components/com_config/Model/ApplicationModel.php
@@ -158,7 +158,7 @@ class ApplicationModel extends FormModel
 		}
 		catch (\Exception $e)
 		{
-			$app->enqueueMessage(Text::_('JLIB_DATABASE_ERROR_DATABASE_CONNECT'), 'error');
+			$app->enqueueMessage(Text::sprintf('COM_CONFIG_ERROR_DATABASE_NOT_AVAILABLE', $e->getCode(), $e->getMessage()), 'error');
 
 			return false;
 		}

--- a/administrator/language/en-GB/en-GB.com_config.ini
+++ b/administrator/language/en-GB/en-GB.com_config.ini
@@ -20,6 +20,7 @@ COM_CONFIG_ERROR_CONFIGURATION_PHP_NOTUNWRITABLE="Could not make configuration.p
 COM_CONFIG_ERROR_CONFIGURATION_PHP_NOTWRITABLE="Could not make configuration.php writable."
 COM_CONFIG_ERROR_CUSTOM_CACHE_PATH_NOTWRITABLE_USING_DEFAULT="The folder at %1$s is not writable and cannot be used for the cache, using the default %2$s instead."
 COM_CONFIG_ERROR_CUSTOM_SESSION_FILESYSTEM_PATH_NOTWRITABLE_USING_DEFAULT="The folder at %s is not writable and cannot be used to store session data, the default PHP path will be used instead."
+COM_CONFIG_ERROR_DATABASE_NOT_AVAILABLE="Database connection test failed with the following error: <em>%s: %s</em><br/>Database connection settings changes were not saved."
 COM_CONFIG_ERROR_ROOT_ASSET_NOT_FOUND="The asset for global configuration could not be found. Permissions have not been saved."
 COM_CONFIG_ERROR_SSL_NOT_AVAILABLE="HTTPS has not been enabled as it is not available on this server. HTTPS connection test failed with the following error: <em>%s</em>"
 COM_CONFIG_ERROR_SSL_NOT_AVAILABLE_HTTP_CODE="HTTPS version of the site returned an invalid HTTP status code."


### PR DESCRIPTION
If not checked here the connection error on save (for instance using a unix socket in "localhost") will not be captured which will put the site down until someone manualy changes the configuration.php file.
