### PR TITLE
[4.1] Improvements for the build/deleted_file_check.php script

### DIFF
--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -29,8 +29,6 @@ use Joomla\CMS\Version;
  */
 const PHP_TAB = "\t";
 
-const PREVIOUS_VERSION = '3.10';
-
 function usage($command)
 {
 	echo PHP_EOL;
@@ -106,6 +104,20 @@ if (!is_dir($options['to']) && !(is_file($options['to']) && substr(strtolower($o
 
 	exit(1);
 }
+
+// Directories to skip for the check
+$excludedFolders = [
+	'administrator/components/com_search',
+	'components/com_search',
+	'images/sampledata',
+	'installation',
+	'media/plg_quickicon_eos310',
+	'media/system/images',
+	'modules/mod_search',
+	'plugins/fields/repeatable',
+	'plugins/quickicon/eos310',
+	'plugins/search',
+];
 
 /**
  * @param   string  $folderPath      Path to the folder with the extracted full package
@@ -220,20 +232,6 @@ function readZipFile($filePath, $excludeFolders): stdClass
 
 	return $return;
 }
-
-// Directories to skip for the check
-$excludedFolders = [
-	'administrator/components/com_search',
-	'components/com_search',
-	'images/sampledata',
-	'installation',
-	'media/plg_quickicon_eos310',
-	'media/system/images',
-	'modules/mod_search',
-	'plugins/fields/repeatable',
-	'plugins/quickicon/eos310',
-	'plugins/search',
-];
 
 // Read files and folders lists from folders or zip files
 if (is_dir($options['from']))

--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -1,16 +1,20 @@
 <?php
 /**
- * This file is used to build the list of deleted files between two reference points.
+ * This file is used to build the lists of deleted files, deleted folders and
+ * renamed files between two Joomla versions.
  *
  * This script requires one parameter:
  *
- * --from - The git commit reference to use as the starting point for the comparison.
+ * --from - Full package zip file or folder with unpacked full package of the
+ *          starting point for the comparison, i.e. the older version.
  *
  * This script has one additional optional parameter:
  *
- * --to - The git commit reference to use as the ending point for the comparison.
+ * --to - Full package zip file or folder with unpacked full package of the
+ *        ending point for the comparison, i.e. the newer version.
  *
- * The reference parameters may be any valid identifier (i.e. a branch, tag, or commit SHA)
+ * If the "to" parameter is not given, the full package zip from a previous
+ * run of the build script is used, if present.
  *
  * @package    Joomla.Build
  *
@@ -18,17 +22,28 @@
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
+use Joomla\CMS\Version;
+
 /*
  * Constants
  */
 const PHP_TAB = "\t";
 
+const PREVIOUS_VERSION = '3.10';
+
 function usage($command)
 {
 	echo PHP_EOL;
 	echo 'Usage: php ' . $command . ' [options]' . PHP_EOL;
-	echo PHP_TAB . '--from <ref>:' . PHP_TAB . 'Starting commit reference (branch/tag)' . PHP_EOL;
-	echo PHP_TAB . '--to <ref>:' . PHP_TAB . 'Ending commit reference (branch/tag) [optional]' . PHP_EOL;
+	echo PHP_TAB . '--from <path>:' . PHP_TAB . 'Path to starting version' . PHP_EOL;
+	echo PHP_TAB . '--to <path>:' . PHP_TAB . 'Path to ending version [optional]' . PHP_EOL;
+	echo PHP_EOL;
+	echo '<path> can be either of the following:' . PHP_EOL;
+	echo PHP_TAB . '- Path to a full package Zip file.' . PHP_EOL;
+	echo PHP_TAB . '- Path to a directory where a full package Zip file has been extracted to.' . PHP_EOL;
+	echo PHP_EOL;
+	echo 'If the "to" parameter is not specified, file "build/tmp/packages/*Full_Package.zip"' . PHP_EOL;
+	echo 'is used if it exists from a previous run of the build script.' . PHP_EOL;
 	echo PHP_EOL;
 }
 
@@ -38,120 +53,331 @@ function usage($command)
 
 $options = getopt('', array('from:', 'to::'));
 
-// We need the from reference, otherwise we're doomed to fail
+// We need the "from" parameter, otherwise we're doomed to fail
 if (empty($options['from']))
 {
 	echo PHP_EOL;
-	echo 'Missing starting directory' . PHP_EOL;
+	echo 'Missing "from" parameter' . PHP_EOL;
 
 	usage($argv[0]);
 
 	exit(1);
 }
 
-// Missing the to reference?  No problem, grab the current HEAD
+// Import the version class to get the version information
+define('JPATH_PLATFORM', 1);
+require_once dirname(__DIR__) . '/libraries/src/Version.php';
+
+// If the "to" parameter is not specified, use the default
 if (empty($options['to']))
 {
-	echo PHP_EOL;
-	echo 'Missing ending directory' . PHP_EOL;
+	$fullVersion      = (new Version)->getShortVersion();
+	$packageStability = str_replace(' ', '_', Version::DEV_STATUS);
+	$packageFile      = __DIR__ . '/tmp/packages/Joomla_' . $fullVersion . '-' . $packageStability . '-Full_Package.zip';
 
-	usage($argv[0]);
+	if (is_file($packageFile))
+	{
+		$options['to'] = $packageFile;
+	}
+	else
+	{
+		echo PHP_EOL;
+		echo 'Missing "to" parameter and no zip file "' . $packageFile . '" found.' . PHP_EOL;
+
+		usage($argv[0]);
+
+		exit(1);
+	}
+}
+
+// Function to get the version information from 'administrator/manifests/files/joomla.xml' in a folder
+function getVersionFromFolder($folderPath): string
+{
+	$return = '';
+
+	$xml = simplexml_load_file($folderPath . '/administrator/manifests/files/joomla.xml');
+
+	if ($xml instanceof \SimpleXMLElement && isset($xml->version))
+	{
+		$return = (string) $xml->version;
+	}
+
+	if ($return === '')
+	{
+		echo PHP_EOL;
+		echo 'Could not read version from file "' . $folderPath . '/administrator/manifests/files/joomla.xml".' . PHP_EOL;
+
+		exit(1);
+	}
+
+	return $return;
+}
+
+// Function to get the version information from 'administrator/manifests/files/joomla.xml' in a zip file
+function getVersionFromZipFile($filePath): string
+{
+	$return = '';
+
+	$zipArchive = new ZipArchive();
+
+	if ($zipArchive->open($filePath) !== true)
+	{
+		echo PHP_EOL;
+		echo 'Could not open zip archive "' . $filePath . '".' . PHP_EOL;
+
+		exit(1);
+	}
+
+	if (($xmlFileContent = $zipArchive->getFromName('administrator/manifests/files/joomla.xml')) !== false)
+	{
+		$xml = simplexml_load_string($xmlFileContent);
+
+		if ($xml instanceof \SimpleXMLElement && isset($xml->version))
+		{
+			$return = (string) $xml->version;
+		}
+	}
+
+	$zipArchive->close();
+
+	if ($return === '')
+	{
+		echo PHP_EOL;
+		echo 'Could not extract version from zip file "' . $filePath . '".' . PHP_EOL;
+
+		exit(1);
+	}
+
+	return $return;
+}
+
+// Check from and to if folder or zip file and set versions
+if (is_dir($options['from']))
+{
+	$fromVersion = getVersionFromFolder($options['from']);
+}
+elseif (is_file($options['from']) && substr(strtolower($options['from']), -4) === '.zip')
+{
+	$fromVersion = getVersionFromZipFile($options['from']);
+}
+else
+{
+	echo PHP_EOL;
+	echo 'The "from" parameter is neither a directory nor a zip file' . PHP_EOL;
 
 	exit(1);
 }
 
-// Directories to skip for the check (needs to include anything from J3 we want to keep)
-$previousReleaseExclude = [
-	$options['from'] . '/administrator/components/com_search',
-	$options['from'] . '/components/com_search',
-	$options['from'] . '/images/sampledata',
-	$options['from'] . '/installation',
-	$options['from'] . '/media/plg_quickicon_eos310',
-	$options['from'] . '/media/system/images',
-	$options['from'] . '/modules/mod_search',
-	$options['from'] . '/plugins/fields/repeatable',
-	$options['from'] . '/plugins/quickicon/eos310',
-	$options['from'] . '/plugins/search',
-];
-
-/**
- * @param   SplFileInfo                      $file      The file being checked
- * @param   mixed                            $key       ?
- * @param   RecursiveCallbackFilterIterator  $iterator  The iterator being processed
- *
- * @return bool True if you need to recurse or if the item is acceptable
- */
-$previousReleaseFilter = function ($file, $key, $iterator) use ($previousReleaseExclude) {
-	if ($iterator->hasChildren() && !in_array($file->getPathname(), $previousReleaseExclude))
-	{
-		return true;
-	}
-
-	return $file->isFile();
-};
-
-// Directories to skip for the check
-$newReleaseExclude = [
-	$options['to'] . '/installation'
-];
-
-/**
- * @param   SplFileInfo                      $file      The file being checked
- * @param   mixed                            $key       ?
- * @param   RecursiveCallbackFilterIterator  $iterator  The iterator being processed
- *
- * @return bool True if you need to recurse or if the item is acceptable
- */
-$newReleaseFilter = function ($file, $key, $iterator) use ($newReleaseExclude) {
-	if ($iterator->hasChildren() && !in_array($file->getPathname(), $newReleaseExclude))
-	{
-		return true;
-	}
-
-	return $file->isFile();
-};
-
-$previousReleaseDirIterator = new RecursiveDirectoryIterator($options['from'], RecursiveDirectoryIterator::SKIP_DOTS);
-$previousReleaseIterator = new RecursiveIteratorIterator(
-	new RecursiveCallbackFilterIterator($previousReleaseDirIterator, $previousReleaseFilter),
-	RecursiveIteratorIterator::SELF_FIRST
-);
-$previousReleaseFiles = [];
-$previousReleaseFolders = [];
-
-foreach ($previousReleaseIterator as $info)
+if (is_dir($options['to']))
 {
-	if ($info->isDir())
-	{
-		$previousReleaseFolders[] = "'" . str_replace($options['from'], '', $info->getPathname()) . "',";
-		continue;
-	}
+	$toVersion = getVersionFromFolder($options['to']);
+}
+elseif (is_file($options['to']) && substr(strtolower($options['to']), -4) === '.zip')
+{
+	$toVersion = getVersionFromZipFile($options['to']);
+}
+else
+{
+	echo PHP_EOL;
+	echo 'The "to" parameter is neither a directory nor a zip file' . PHP_EOL;
 
-	$previousReleaseFiles[] = "'" . str_replace($options['from'], '', $info->getPathname()) . "',";
+	exit(1);
 }
 
-$newReleaseDirIterator = new RecursiveDirectoryIterator($options['to'], RecursiveDirectoryIterator::SKIP_DOTS);
-$newReleaseIterator = new RecursiveIteratorIterator(
-	new RecursiveCallbackFilterIterator($newReleaseDirIterator, $newReleaseFilter),
-	RecursiveIteratorIterator::SELF_FIRST
-);
-$newReleaseFiles = [];
-$newReleaseFolders = [];
+// Check versions
+$fromIsPreviousMajor = preg_match('/^' . str_replace('.', '\.', PREVIOUS_VERSION) . '\..*/', $fromVersion) === 1;
 
-foreach ($newReleaseIterator as $info)
+if (!$fromIsPreviousMajor && preg_match('/^' . Version::MAJOR_VERSION . '\..*/', $fromVersion) !== 1)
 {
-	if ($info->isDir())
-	{
-		$newReleaseFolders[] = "'" . str_replace($options['to'], '', $info->getPathname()) . "',";
-		continue;
-	}
+	echo PHP_EOL;
+	echo 'The starting version has to be "' . PREVIOUS_VERSION . '.*" or "' . Version::MAJOR_VERSION . '.*".' . PHP_EOL;
 
-	$newReleaseFiles[] = "'" . str_replace($options['to'], '', $info->getPathname()) . "',";
+	exit(1);
 }
 
-$filesDifference = array_diff($previousReleaseFiles, $newReleaseFiles);
+if (preg_match('/^' . Version::MAJOR_VERSION . '\..*/', $toVersion) !== 1)
+{
+	echo PHP_EOL;
+	echo 'The ending version has to be "' . Version::MAJOR_VERSION . '.*".' . PHP_EOL;
 
-$foldersDifference = array_diff($previousReleaseFolders, $newReleaseFolders);
+	exit(1);
+}
+
+if (version_compare($fromVersion, $toVersion, '>='))
+{
+	echo PHP_EOL;
+	echo 'The starting version has to be lower than the ending version.' . PHP_EOL;
+
+	exit(1);
+}
+
+/**
+ * @param   string  $folderPath      Path to the folder with the extracted full package
+ * @param   array   $excludeFolders  Excluded folders
+ *
+ * @return  stdClass  An object with arrays "files" and "folders"
+ */
+function readFolder($folderPath, $excludeFolders): stdClass
+{
+	$return = new stdClass;
+
+	$return->files   = [];
+	$return->folders = [];
+
+	$skipFolders = [];
+
+	foreach ($excludeFolders as $excludeFolder)
+	{
+		$skipFolders[] = $folderPath . '/' . $excludeFolder;
+	}
+
+	/**
+	 * @param   SplFileInfo                      $file      The file being checked
+	 * @param   mixed                            $key       ?
+	 * @param   RecursiveCallbackFilterIterator  $iterator  The iterator being processed
+	 *
+	 * @return  bool  True if you need to recurse or if the item is acceptable
+	 */
+	$releaseFilter = function ($file, $key, $iterator) use ($skipFolders) {
+		if ($iterator->hasChildren() && !in_array($file->getPathname(), $skipFolders))
+		{
+			return true;
+		}
+
+		return $file->isFile();
+	};
+
+	$releaseDirIterator = new RecursiveDirectoryIterator($folderPath, RecursiveDirectoryIterator::SKIP_DOTS);
+	$releaseIterator = new RecursiveIteratorIterator(
+		new RecursiveCallbackFilterIterator($releaseDirIterator, $releaseFilter),
+		RecursiveIteratorIterator::SELF_FIRST
+	);
+
+	foreach ($releaseIterator as $info)
+	{
+		if ($info->isDir())
+		{
+			$return->folders[] = "'" . str_replace($folderPath, '', $info->getPathname()) . "',";
+			continue;
+		}
+
+		$return->files[] = "'" . str_replace($folderPath, '', $info->getPathname()) . "',";
+	}
+
+	return $return;
+}
+
+/**
+ * @param   string  $filePath        Path to the full package zip file
+ * @param   array   $excludeFolders  Excluded folders
+ *
+ * @return  stdClass  An object with arrays "files" and "folders"
+ */
+function readZipFile($filePath, $excludeFolders): stdClass
+{
+	$return = new stdClass;
+
+	$return->files   = [];
+	$return->folders = [];
+
+	$zipArchive = new ZipArchive();
+
+	if ($zipArchive->open($filePath) !== true)
+	{
+		echo PHP_EOL;
+		echo 'Could not open zip archive "' . $filePath . '".' . PHP_EOL;
+
+		exit(1);
+	}
+
+	$excludeRegexp = '/^(';
+
+	foreach ($excludeFolders as $excludeFolder)
+	{
+		$excludeRegexp .= preg_quote($excludeFolder, '/') . '|';
+	}
+
+	$excludeRegexp = rtrim($excludeRegexp, '|') . ')\/.*/';
+
+	for ($i = 0; $i < $zipArchive->numFiles; $i++)
+	{
+		$stat = $zipArchive->statIndex($i);
+
+		$name = $stat['name'];
+
+		if (preg_match($excludeRegexp, $name) === 1)
+		{
+			continue;
+		}
+
+		if (substr($name, -1) === '/')
+		{
+			$return->folders[] = "'/" . rtrim($name, '/') . "',";
+		}
+		else
+		{
+			$return->files[] = "'/" . $name . "',";
+		}
+	}
+
+	$zipArchive->close();
+
+	return $return;
+}
+
+// Directories of the previous major version to skip for the check
+$previousMajorExclude = [
+	'administrator/components/com_search',
+	'components/com_search',
+	'images/sampledata',
+	'installation',
+	'media/plg_quickicon_eos310',
+	'media/system/images',
+	'modules/mod_search',
+	'plugins/fields/repeatable',
+	'plugins/quickicon/eos310',
+	'plugins/search',
+];
+
+// Directories of the current major version to skip for the check
+$currentMajorExclude = [
+	'installation'
+];
+
+if ($fromIsPreviousMajor)
+{
+	$excludedFolders = array_unique(array_merge($previousMajorExclude, $currentMajorExclude));
+}
+else
+{
+	$excludedFolders = $currentMajorExclude;
+}
+
+asort($excludedFolders);
+
+// Read files and folders lists from folders or zip files
+if (is_dir($options['from']))
+{
+	$previousReleaseFilesFolders = readFolder($options['from'], $excludedFolders);
+}
+else
+{
+	$previousReleaseFilesFolders = readZipFile($options['from'], $excludedFolders);
+}
+
+if (is_dir($options['to']))
+{
+	$newReleaseFilesFolders = readFolder($options['to'], $excludedFolders);
+}
+else
+{
+	$newReleaseFilesFolders = readZipFile($options['to'], $excludedFolders);
+}
+
+$filesDifferenceAdd      = array_diff($newReleaseFilesFolders->files, $previousReleaseFilesFolders->files);
+$filesDifferenceDelete   = array_diff($previousReleaseFilesFolders->files, $newReleaseFilesFolders->files);
+$foldersDifferenceAdd    = array_diff($newReleaseFilesFolders->folders, $previousReleaseFilesFolders->folders);
+$foldersDifferenceDelete = array_diff($previousReleaseFilesFolders->folders, $newReleaseFilesFolders->folders);
 
 // Specific files (e.g. language files) that we want to keep on upgrade
 $filesToKeep = [
@@ -191,18 +417,18 @@ $foldersToKeep = [
 // Remove folders from the results which we want to keep on upgrade
 foreach ($foldersToKeep as $folder)
 {
-	if (($key = array_search($folder, $foldersDifference)) !== false) {
-		unset($foldersDifference[$key]);
+	if (($key = array_search($folder, $foldersDifferenceDelete)) !== false) {
+		unset($foldersDifferenceDelete[$key]);
 	}
 }
 
-asort($filesDifference);
-rsort($foldersDifference);
+asort($filesDifferenceDelete);
+rsort($foldersDifferenceDelete);
 
 $deletedFiles = [];
 $renamedFiles = [];
 
-foreach ($filesDifference as $file)
+foreach ($filesDifferenceDelete as $file)
 {
 	// Don't remove any specific files (e.g. language files) that we want to keep on upgrade
 	if (array_search($file, $filesToKeep) !== false)
@@ -211,7 +437,7 @@ foreach ($filesDifference as $file)
 	}
 
 	// Check for files which might have been renamed only
-	$matches = preg_grep('/^' . preg_quote($file, '/') . '$/i', $newReleaseFiles);
+	$matches = preg_grep('/^' . preg_quote($file, '/') . '$/i', $newReleaseFilesFolders->files);
 
 	if ($matches !== false)
 	{
@@ -222,7 +448,7 @@ foreach ($filesDifference as $file)
 				// File has been renamed only: Add to renamed files list
 				$renamedFiles[] = substr($file, 0, -1) . ' => ' . $match;
 
-				// Go on with the next file in $filesDifference
+				// Go on with the next file in $filesDifferenceDelete
 				continue 2;
 			}
 		}
@@ -233,9 +459,60 @@ foreach ($filesDifference as $file)
 }
 
 // Write the lists to files for later reference
-file_put_contents(__DIR__ . '/deleted_files.txt', implode("\n", $deletedFiles));
-file_put_contents(__DIR__ . '/deleted_folders.txt', implode("\n", $foldersDifference));
-file_put_contents(__DIR__ . '/renamed_files.txt', implode("\n", $renamedFiles));
+$addedFilesFile     = __DIR__ . '/added_files.txt';
+$addedFoldersFile   = __DIR__ . '/added_folders.txt';
+$deletedFilesFile   = __DIR__ . '/deleted_files.txt';
+$deletedFoldersFile = __DIR__ . '/deleted_folders.txt';
+$renamedFilesFile   = __DIR__ . '/renamed_files.txt';
+
+@unlink($addedFilesFile);
+@unlink($addedFoldersFile);
+@unlink($deletedFilesFile);
+@unlink($deletedFoldersFile);
+@unlink($renamedFilesFile);
+
+if (count($filesDifferenceAdd) > 0)
+{
+	file_put_contents($addedFilesFile, implode("\n", $filesDifferenceAdd));
+}
+
+if (count($foldersDifferenceAdd) > 0)
+{
+	file_put_contents($addedFoldersFile, implode("\n", $foldersDifferenceAdd));
+}
+
+if (count($deletedFiles) > 0)
+{
+	file_put_contents($deletedFilesFile, implode("\n", $deletedFiles));
+}
+
+if (count($foldersDifferenceDelete) > 0)
+{
+	file_put_contents($deletedFoldersFile, implode("\n", $foldersDifferenceDelete));
+}
+
+if (count($renamedFiles) > 0)
+{
+	file_put_contents($renamedFilesFile, implode("\n", $renamedFiles));
+}
 
 echo PHP_EOL;
-echo 'There are ' . count($deletedFiles) . ' deleted files, ' . count($foldersDifference) .  ' deleted folders and ' . count($renamedFiles) .  ' renamed files in comparison to "' . $options['from'] . '"' . PHP_EOL;
+echo 'There are ' . PHP_EOL;
+echo ' - ' . count($filesDifferenceAdd) . ' added files, ' . PHP_EOL;
+echo ' - ' . count($foldersDifferenceAdd) . ' added folders, ' . PHP_EOL;
+echo ' - ' . count($deletedFiles) . ' deleted files, ' . PHP_EOL;
+echo ' - ' . count($foldersDifferenceDelete) .  ' deleted folders and ' . PHP_EOL;
+echo ' - ' . count($renamedFiles) .  ' renamed files' . PHP_EOL;
+echo PHP_EOL;
+echo 'in comparison' . PHP_EOL;
+echo ' from "' . $options['from'] . '"' . PHP_EOL;
+echo ' to "' . $options['to'] . '"' . PHP_EOL;
+echo PHP_EOL;
+echo 'The following folders and their subfolders have been skipped so they were not included in the comparison:' . PHP_EOL;
+
+foreach ($excludedFolders as $excludedFolder)
+{
+	echo ' - ' . $excludedFolder . PHP_EOL;
+}
+
+echo PHP_EOL;


### PR DESCRIPTION
This PR here is just for me for preparing my real PR to the CMS repo.

### Summary of Changes

- Ability to use zip files without unpacking
- Let "to" parameter really be optional.
- Create also lists of files and folders which have been added
 with respect to excluded folders.
 These lists can be used to check if files or folders should be removed from the lists of stuff to be deleted because the files or folders have been added back again by the new release.
- Let the help and the doc blocks tell the truth (before they were outdated).

### Testing Instructions

Will be added.

### Actual result BEFORE applying this Pull Request

Will be added.

### Expected result AFTER applying this Pull Request

Will be added.

### Documentation Changes Required

None.