### PR TITLE
[4.2] [WiP] Add unit tests for the database schema checker's ChangeItem class

### DIFF
--- a/tests/Unit/Libraries/Cms/Schema/ChangeItemTest.php
+++ b/tests/Unit/Libraries/Cms/Schema/ChangeItemTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Schema
+ *
+ * @copyright   (C) 2022 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+namespace Joomla\Tests\Unit\Libraries\Cms\Schema;
+
+use Joomla\CMS\Schema\ChangeItem;
+use Joomla\Database\DatabaseDriver;
+
+class ChangeItemTest extends \PHPUnit\Framework\TestCase
+{
+	/**
+	 * @var  DatabaseDriver|MockObject
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected $db;
+
+	/**
+	 * Sets up the database mock.
+	 * This method is called before a test is executed.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function setUp():void
+	{
+		$this->db = $this->createMock(DatabaseDriver::class);
+	}
+
+	/**
+	 * Data provider for the getInstance() test case
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function dataGetInstance(): array
+	{
+		return [
+			'MySQL'      => ['mysql', 'Mysql'],
+			'PostgreSQL' => ['postgresql', 'Postgresql'],
+		];
+	}
+
+	/**
+	 * @param   string  $servertype    The value to be returned by the getServerType method of the database driver
+	 * @param   string  $itemSubclass  The subclass of ChangeItem that is expected
+	 *
+	 * @dataProvider  dataGetInstance
+	 *
+	 * @return void
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testGetInstanceReturnsTheCorrectObject($serverType, $itemSubclass)
+	{
+		$this->db->expects($this->once())
+			->method('getServerType')
+			->willReturn($serverType);
+
+		$item = ChangeItem::getInstance($this->db, '/not/really/used/4.0.0-2018-03-05.sql', 'QUERY NOT REALLY USED');
+
+		$this->assertInstanceOf('\\Joomla\\CMS\\Schema\\ChangeItem\\' . $itemSubclass . 'ChangeItem', $item, 'The correct ChangeItem subclass was not instantiated');
+	}
+
+	/**
+	 * @return void
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testGetInstanceThrowsAnExceptionForAnUnsupportedDbServerType()
+	{
+		$this->db->expects($this->once())
+			->method('getServerType')
+			->willReturn('sqlite');
+
+		$this->expectException(\RuntimeException::class);
+
+		$item = ChangeItem::getInstance($this->db, '/not/really/used/4.0.0-2018-03-05.sql', 'QUERY NOT REALLY USED');
+	}
+}

--- a/tests/Unit/Libraries/Cms/Schema/ChangeItemTest.php
+++ b/tests/Unit/Libraries/Cms/Schema/ChangeItemTest.php
@@ -28,7 +28,7 @@ class ChangeItemTest extends UnitTestCase
 	/**
 	 * @testdox  has the right subclass for the given database server type
 	 *
-	 * @dataProvider  getInstanceSubclassData
+	 * @dataProvider  dataGetInstanceSubclass
 	 *
 	 * @param   string  $servertype    The value returned by the getServerType method of the database driver
 	 * @param   string  $itemSubclass  The subclass of ChangeItem that is expected
@@ -55,7 +55,7 @@ class ChangeItemTest extends UnitTestCase
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function testGetInstanceUnsupportedDatabaseServerType()
+	public function testGetInstanceUnsupportedDatabaseType()
 	{
 		$db = $this->createStub(DatabaseDriver::class);
 
@@ -73,7 +73,7 @@ class ChangeItemTest extends UnitTestCase
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function getInstanceSubclassData(): array
+	public function dataGetInstanceSubclass(): array
 	{
 		return [
 			// 'data set name' => ['database server type', 'ChangeItem subclass']

--- a/tests/Unit/Libraries/Cms/Schema/ChangeItemTest.php
+++ b/tests/Unit/Libraries/Cms/Schema/ChangeItemTest.php
@@ -10,6 +10,8 @@
 namespace Joomla\Tests\Unit\Libraries\Cms\Schema;
 
 use Joomla\CMS\Schema\ChangeItem;
+use Joomla\CMS\Schema\ChangeItem\MysqlChangeItem;
+use Joomla\CMS\Schema\ChangeItem\PostgresqlChangeItem;
 use Joomla\Database\DatabaseDriver;
 use Joomla\Tests\Unit\UnitTestCase;
 
@@ -45,7 +47,7 @@ class ChangeItemTest extends UnitTestCase
 
 		$item = ChangeItem::getInstance($db, '', '');
 
-		$this->assertInstanceOf('\\Joomla\\CMS\\Schema\\ChangeItem\\' . $itemSubclass . 'ChangeItem', $item);
+		$this->assertInstanceOf($itemSubclass, $item);
 	}
 
 	/**
@@ -77,8 +79,8 @@ class ChangeItemTest extends UnitTestCase
 	{
 		return [
 			// 'data set name' => ['database server type', 'ChangeItem subclass']
-			'MySQL'      => ['mysql', 'Mysql'],
-			'PostgreSQL' => ['postgresql', 'Postgresql'],
+			'MySQL'      => ['mysql', MysqlChangeItem::class],
+			'PostgreSQL' => ['postgresql', PostgresqlChangeItem::class],
 		];
 	}
 }

--- a/tests/Unit/Libraries/Cms/Schema/ChangeItemTest.php
+++ b/tests/Unit/Libraries/Cms/Schema/ChangeItemTest.php
@@ -49,12 +49,15 @@ class ChangeItemTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
+	 * @testdox  A ChangeItem instance is retreived with the right subclass for the given database server type
+	 *
+	 * @covers        Joomla\CMS\Schema\ChangeItem::getInstance
+	 * @dataProvider  dataGetInstance
+	 *
 	 * @param   string  $servertype    The value to be returned by the getServerType method of the database driver
 	 * @param   string  $itemSubclass  The subclass of ChangeItem that is expected
 	 *
-	 * @dataProvider  dataGetInstance
-	 *
-	 * @return void
+	 * @return  void
 	 * @since   __DEPLOY_VERSION__
 	 */
 	public function testGetInstanceReturnsTheCorrectObject($serverType, $itemSubclass)
@@ -69,7 +72,11 @@ class ChangeItemTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @return void
+	 * @testdox  A runtime exception is thrown when trying to retrieve a ChangeItem instance for an invalid database server type
+	 *
+	 * @covers  Joomla\CMS\Schema\ChangeItem::getInstance
+	 *
+	 * @return  void
 	 * @since   __DEPLOY_VERSION__
 	 */
 	public function testGetInstanceThrowsAnExceptionForAnUnsupportedDbServerType()

--- a/tests/Unit/Libraries/Cms/Schema/ChangeItemTest.php
+++ b/tests/Unit/Libraries/Cms/Schema/ChangeItemTest.php
@@ -26,18 +26,18 @@ use Joomla\Tests\Unit\UnitTestCase;
 class ChangeItemTest extends UnitTestCase
 {
 	/**
-	 * @testdox  has the right subclass
+	 * @testdox  has the right subclass for the given database server type
 	 *
-	 * @dataProvider  constructData
+	 * @dataProvider  getInstanceSubclassData
 	 *
-	 * @param   string  $servertype    The value to be returned by the getServerType method of the database driver
+	 * @param   string  $servertype    The value returned by the getServerType method of the database driver
 	 * @param   string  $itemSubclass  The subclass of ChangeItem that is expected
 	 *
 	 * @return  void
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function testChangeItemSubclass($serverType, $itemSubclass)
+	public function testGetInstanceSubclass($serverType, $itemSubclass)
 	{
 		$db = $this->createStub(DatabaseDriver::class);
 
@@ -45,17 +45,17 @@ class ChangeItemTest extends UnitTestCase
 
 		$item = ChangeItem::getInstance($db, '', '');
 
-		$this->assertInstanceOf('\\Joomla\\CMS\\Schema\\ChangeItem\\' . $itemSubclass . 'ChangeItem', $item, 'The correct ChangeItem subclass was not instantiated');
+		$this->assertInstanceOf('\\Joomla\\CMS\\Schema\\ChangeItem\\' . $itemSubclass . 'ChangeItem', $item);
 	}
 
 	/**
-	 * @testdox  throws a runtime exception if invalid database server type
+	 * @testdox  throws a runtime exception with an unsupported database server type
 	 *
 	 * @return  void
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function testChangeItemException()
+	public function testGetInstanceUnsupportedDatabaseServerType()
 	{
 		$db = $this->createStub(DatabaseDriver::class);
 
@@ -67,15 +67,16 @@ class ChangeItemTest extends UnitTestCase
 	}
 
 	/**
-	 * Provides constructor data for test methods
+	 * Provides constructor data for the testGetInstanceSubclass method
 	 *
 	 * @return  array
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function constructData(): array
+	public function getInstanceSubclassData(): array
 	{
 		return [
+			// 'data set name' => ['database server type', 'ChangeItem subclass']
 			'MySQL'      => ['mysql', 'Mysql'],
 			'PostgreSQL' => ['postgresql', 'Postgresql'],
 		];

--- a/tests/Unit/Libraries/Cms/Schema/ChangeItemTest.php
+++ b/tests/Unit/Libraries/Cms/Schema/ChangeItemTest.php
@@ -6,88 +6,78 @@
  * @copyright   (C) 2022 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
+
 namespace Joomla\Tests\Unit\Libraries\Cms\Schema;
 
 use Joomla\CMS\Schema\ChangeItem;
 use Joomla\Database\DatabaseDriver;
 use Joomla\Tests\Unit\UnitTestCase;
 
+/**
+ * Test class for \Joomla\CMS\Schema\ChangeItem
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Schema
+ *
+ * @testdox     The ChangeItem
+ *
+ * @since       __DEPLOY_VERSION__
+ */
 class ChangeItemTest extends UnitTestCase
 {
 	/**
-	 * @var  DatabaseDriver|MockObject
+	 * @testdox  has the right subclass
 	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	protected $db;
-
-	/**
-	 * Sets up the database mock.
-	 * This method is called before a test is executed.
-	 *
-	 * @return  void
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	protected function setUp():void
-	{
-		$this->db = $this->createMock(DatabaseDriver::class);
-	}
-
-	/**
-	 * Data provider for the getInstance() test case
-	 *
-	 * @return  array
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	public function dataGetInstance(): array
-	{
-		return [
-			'MySQL'      => ['mysql', 'Mysql'],
-			'PostgreSQL' => ['postgresql', 'Postgresql'],
-		];
-	}
-
-	/**
-	 * @testdox  A ChangeItem instance is retreived with the right subclass for the given database server type
-	 *
-	 * @covers        Joomla\CMS\Schema\ChangeItem::getInstance
-	 * @dataProvider  dataGetInstance
+	 * @dataProvider  constructData
 	 *
 	 * @param   string  $servertype    The value to be returned by the getServerType method of the database driver
 	 * @param   string  $itemSubclass  The subclass of ChangeItem that is expected
 	 *
 	 * @return  void
+	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function testGetInstanceReturnsTheCorrectObject($serverType, $itemSubclass)
+	public function testChangeItemSubclass($serverType, $itemSubclass)
 	{
-		$this->db->expects($this->once())
-			->method('getServerType')
-			->willReturn($serverType);
+		$db = $this->createStub(DatabaseDriver::class);
 
-		$item = ChangeItem::getInstance($this->db, '/not/really/used/4.0.0-2018-03-05.sql', 'QUERY NOT REALLY USED');
+		$db->method('getServerType')->willReturn($serverType);
+
+		$item = ChangeItem::getInstance($db, '', '');
 
 		$this->assertInstanceOf('\\Joomla\\CMS\\Schema\\ChangeItem\\' . $itemSubclass . 'ChangeItem', $item, 'The correct ChangeItem subclass was not instantiated');
 	}
 
 	/**
-	 * @testdox  A runtime exception is thrown when trying to retrieve a ChangeItem instance for an invalid database server type
-	 *
-	 * @covers  Joomla\CMS\Schema\ChangeItem::getInstance
+	 * @testdox  throws a runtime exception if invalid database server type
 	 *
 	 * @return  void
+	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function testGetInstanceThrowsAnExceptionForAnUnsupportedDbServerType()
+	public function testChangeItemException()
 	{
-		$this->db->expects($this->once())
-			->method('getServerType')
-			->willReturn('sqlite');
+		$db = $this->createStub(DatabaseDriver::class);
+
+		$db->method('getServerType')->willReturn('sqlite');
 
 		$this->expectException(\RuntimeException::class);
 
-		$item = ChangeItem::getInstance($this->db, '/not/really/used/4.0.0-2018-03-05.sql', 'QUERY NOT REALLY USED');
+		$item = ChangeItem::getInstance($db, '', '');
+	}
+
+	/**
+	 * Provides constructor data for test methods
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function constructData(): array
+	{
+		return [
+			'MySQL'      => ['mysql', 'Mysql'],
+			'PostgreSQL' => ['postgresql', 'Postgresql'],
+		];
 	}
 }

--- a/tests/Unit/Libraries/Cms/Schema/ChangeItemTest.php
+++ b/tests/Unit/Libraries/Cms/Schema/ChangeItemTest.php
@@ -10,8 +10,9 @@ namespace Joomla\Tests\Unit\Libraries\Cms\Schema;
 
 use Joomla\CMS\Schema\ChangeItem;
 use Joomla\Database\DatabaseDriver;
+use Joomla\Tests\Unit\UnitTestCase;
 
-class ChangeItemTest extends \PHPUnit\Framework\TestCase
+class ChangeItemTest extends UnitTestCase
 {
 	/**
 	 * @var  DatabaseDriver|MockObject

--- a/tests/Unit/Libraries/Cms/Schema/MysqlChangeItemTest.php
+++ b/tests/Unit/Libraries/Cms/Schema/MysqlChangeItemTest.php
@@ -6,54 +6,71 @@
  * @copyright   (C) 2022 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
+
 namespace Joomla\Tests\Unit\Libraries\Cms\Schema;
 
 use Joomla\CMS\Schema\ChangeItem\MysqlChangeItem;
 use Joomla\Database\Mysqli\MysqliDriver;
 use Joomla\Tests\Unit\UnitTestCase;
 
+/**
+ * Test class for \Joomla\CMS\Schema\ChangeItem\MysqlChangeItem
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Schema
+ *
+ * @testdox     The MysqlChangeItem
+ *
+ * @since       __DEPLOY_VERSION__
+ */
 class MysqlChangeItemTest extends UnitTestCase
 {
 	/**
-	 * @var  MysqliDriver|MockObject
+	 * @testdox  can build the right query
 	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	protected $db;
-
-	/**
-	 * Sets up the database mock.
-	 * This method is called before a test is executed.
+	 * @dataProvider  constructData
+	 *
+	 * @param   array  $options  Options array to inject
+	 * @param   array  $expects  Expected data values
 	 *
 	 * @return  void
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	protected function setUp():void
+	public function testBuildCheckQuery($options, $expects)
 	{
-		$this->db = $this->createMock(MysqliDriver::class);
+		$message = "Test '%s' for query '". $options['query'] . "'";
+		$utf8mb4 = $options['utf8mb4'] ?? true;
 
-		$this->db->expects($this->once())
-			->method('getServerType')
-			->willReturn('mysql');
+		if (!$utf8mb4)
+		{
+			$message .= ' without utf8mb4 support';
+		}
 
-		$this->db->expects($this->any())
-			->method('getPrefix')
-			->willReturn('jos_');
+		$message .= ' failed.';
 
-		$this->db->expects($this->any())
-			->method('quote')->will(
-				$this->returnCallback(function ($arg) {
-					return "'" . $arg . "'";
-				})
-			);
+		$db = $this->createStub(MysqliDriver::class);
+		$db->method('getServerType')->willReturn('mysql');
+		$db->method('getPrefix')->willReturn('jos_');
+		$db->method('hasUTF8mb4Support')->willReturn($utf8mb4); 
+		$db->method('quote')->will(
+			$this->returnCallback(function ($arg) {
+				return "'" . $arg . "'";
+			})
+		);
+		$db->method('quoteName')->will(
+			$this->returnCallback(function ($arg) {
+				return '`' . $arg . '`';
+			})
+		);
 
-		$this->db->expects($this->any())
-			->method('quoteName')->will(
-				$this->returnCallback(function ($arg) {
-					return '`' . $arg . '`';
-				})
-			);
+		$item = new MysqlChangeItem($db, '', $options['query']);
+
+		$this->assertEquals($expects['checkQuery'], $item->checkQuery, sprintf($message, 'checkQuery'));
+		$this->assertEquals($expects['queryType'], $item->queryType, sprintf($message, 'queryType'));
+		$this->assertEquals($expects['checkQueryExpected'], $item->checkQueryExpected, sprintf($message, 'checkQueryExpected'));
+		$this->assertEquals($expects['msgElements'], $item->msgElements, sprintf($message, 'msgElements'));
+		$this->assertEquals($expects['checkStatus'], $item->checkStatus, sprintf($message, 'checkStatus'));
 	}
 
 	/**
@@ -490,42 +507,5 @@ class MysqlChangeItemTest extends UnitTestCase
 				],
 			],
 		];
-	}
-
-	/**
-	 * @testdox  A MysqlChangeItem instance is retreived with the right properties for the given SQL query
-	 *
-	 * @covers        Joomla\CMS\Schema\ChangeItem\MysqlChangeItem::getInstance
-	 * @dataProvider  constructData
-	 *
-	 * @param   array  $options  Options array to inject
-	 * @param   array  $expects  Expected data values
-	 *
-	 * @return  void
-	 * @since   __DEPLOY_VERSION__
-	 */
-	public function testBuildCheckQuery($options, $expects)
-	{
-		$message = "Test '%s' for query '". $options['query'] . "'";
-		$utf8mb4 = $options['utf8mb4'] ?? true;
-
-		if (!$utf8mb4)
-		{
-			$message .= ' without utf8mb4 support';
-		}
-
-		$message .= ' failed.';
-
-		$this->db->expects($this->any())
-			->method('hasUTF8mb4Support')
-			->willReturn($utf8mb4);
-
-		$item = MysqlChangeItem::getInstance($this->db, '/not/really/used/4.0.0-2018-03-05.sql', $options['query']);
-
-		$this->assertEquals($expects['checkQuery'], $item->checkQuery, sprintf($message, 'checkQuery'));
-		$this->assertEquals($expects['queryType'], $item->queryType, sprintf($message, 'queryType'));
-		$this->assertEquals($expects['checkQueryExpected'], $item->checkQueryExpected, sprintf($message, 'checkQueryExpected'));
-		$this->assertEquals($expects['msgElements'], $item->msgElements, sprintf($message, 'msgElements'));
-		$this->assertEquals($expects['checkStatus'], $item->checkStatus, sprintf($message, 'checkStatus'));
 	}
 }

--- a/tests/Unit/Libraries/Cms/Schema/MysqlChangeItemTest.php
+++ b/tests/Unit/Libraries/Cms/Schema/MysqlChangeItemTest.php
@@ -493,12 +493,15 @@ class MysqlChangeItemTest extends UnitTestCase
 	}
 
 	/**
+	 * @testdox  A MysqlChangeItem instance is retreived with the right properties for the given SQL query
+	 *
+	 * @covers        Joomla\CMS\Schema\ChangeItem\MysqlChangeItem::getInstance
+	 * @dataProvider  constructData
+	 *
 	 * @param   array  $options  Options array to inject
 	 * @param   array  $expects  Expected data values
 	 *
-	 * @dataProvider constructData
-	 *
-	 * @return void
+	 * @return  void
 	 * @since   __DEPLOY_VERSION__
 	 */
 	public function testBuildCheckQuery($options, $expects)

--- a/tests/Unit/Libraries/Cms/Schema/MysqlChangeItemTest.php
+++ b/tests/Unit/Libraries/Cms/Schema/MysqlChangeItemTest.php
@@ -1,0 +1,527 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Schema
+ *
+ * @copyright   (C) 2022 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+namespace Joomla\Tests\Unit\Libraries\Cms\Schema;
+
+use Joomla\CMS\Schema\ChangeItem\MysqlChangeItem;
+use Joomla\Database\Mysqli\MysqliDriver;
+
+class MysqlChangeItemTest extends \PHPUnit\Framework\TestCase
+{
+	/**
+	 * @var  MysqliDriver|MockObject
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected $db;
+
+	/**
+	 * Sets up the database mock.
+	 * This method is called before a test is executed.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function setUp():void
+	{
+		$this->db = $this->createMock(MysqliDriver::class);
+
+		$this->db->expects($this->once())
+			->method('getServerType')
+			->willReturn('mysql');
+
+		$this->db->expects($this->any())
+			->method('getPrefix')
+			->willReturn('jos_');
+
+		$this->db->expects($this->any())
+			->method('quote')->will(
+				$this->returnCallback(function ($arg) {
+					return "'" . $arg . "'";
+				})
+			);
+
+		$this->db->expects($this->any())
+			->method('quoteName')->will(
+				$this->returnCallback(function ($arg) {
+					return '`' . $arg . '`';
+				})
+			);
+	}
+
+	/**
+	 * Provides constructor data for test methods
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function constructData(): array
+	{
+		return [
+			[
+				[
+					'query' => 'WHATEVER',
+					'utf8mb4' => null,
+				],
+				[
+					'checkQuery' => null,
+					'queryType' => null,
+					'checkQueryExpected' => 1,
+					'msgElements' => [],
+					'checkStatus' => -1,
+				],
+			],
+			[
+				[
+					'query' => 'ALTER TABLE `#__foo` ADD COLUMN `bar` text',
+					'utf8mb4' => null,
+				],
+				[
+					'checkQuery' => "SHOW COLUMNS IN `#__foo` WHERE field = 'bar'",
+					'queryType' => 'ADD_COLUMN',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_foo'", "'bar'"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				[
+					'query' => 'ALTER TABLE #__foo ADD COLUMN bar text',
+					'utf8mb4' => null,
+				],
+				[
+					'checkQuery' => "SHOW COLUMNS IN #__foo WHERE field = 'bar'",
+					'queryType' => 'ADD_COLUMN',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_foo'", "'bar'"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				[
+					'query' => 'ALTER TABLE `#__foo` ADD INDEX `idx_bar` (`bar`)',
+					'utf8mb4' => null,
+				],
+				[
+					'checkQuery' => "SHOW INDEXES IN `#__foo` WHERE Key_name = 'idx_bar'",
+					'queryType' => 'ADD_INDEX',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_foo'", "'idx_bar'"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				[
+					'query' => 'ALTER TABLE `#__foo` ADD INDEX `idx_bar`(`bar`)',
+					'utf8mb4' => null,
+				],
+				[
+					'checkQuery' => "SHOW INDEXES IN `#__foo` WHERE Key_name = 'idx_bar'",
+					'queryType' => 'ADD_INDEX',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_foo'", "'idx_bar'"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				[
+					'query' => 'ALTER TABLE `#__foo` ADD KEY `idx_bar` (`bar`)',
+					'utf8mb4' => null,
+				],
+				[
+					'checkQuery' => "SHOW INDEXES IN `#__foo` WHERE Key_name = 'idx_bar'",
+					'queryType' => 'ADD_INDEX',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_foo'", "'idx_bar'"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				[
+					'query' => 'ALTER TABLE `#__foo` ADD KEY `idx_bar`(`bar`)',
+					'utf8mb4' => null,
+				],
+				[
+					'checkQuery' => "SHOW INDEXES IN `#__foo` WHERE Key_name = 'idx_bar'",
+					'queryType' => 'ADD_INDEX',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_foo'", "'idx_bar'"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				[
+					'query' => 'ALTER TABLE `#__foo` ADD UNIQUE `idx_bar` (`bar`)',
+					'utf8mb4' => null,
+				],
+				[
+					'checkQuery' => "SHOW INDEXES IN `#__foo` WHERE Key_name = 'idx_bar'",
+					'queryType' => 'ADD_INDEX',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_foo'", "'idx_bar'"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				[
+					'query' => 'ALTER TABLE `#__foo` ADD UNIQUE `idx_bar`(`bar`)',
+					'utf8mb4' => null,
+				],
+				[
+					'checkQuery' => "SHOW INDEXES IN `#__foo` WHERE Key_name = 'idx_bar'",
+					'queryType' => 'ADD_INDEX',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_foo'", "'idx_bar'"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				[
+					'query' => 'ALTER TABLE `#__foo` ADD UNIQUE INDEX `idx_bar` (`bar`)',
+					'utf8mb4' => null,
+				],
+				[
+					'checkQuery' => "SHOW INDEXES IN `#__foo` WHERE Key_name = 'idx_bar'",
+					'queryType' => 'ADD_INDEX',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_foo'", "'idx_bar'"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				[
+					'query' => 'ALTER TABLE `#__foo` ADD UNIQUE INDEX `idx_bar`(`bar`)',
+					'utf8mb4' => null,
+				],
+				[
+					'checkQuery' => "SHOW INDEXES IN `#__foo` WHERE Key_name = 'idx_bar'",
+					'queryType' => 'ADD_INDEX',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_foo'", "'idx_bar'"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				[
+					'query' => 'ALTER TABLE `#__foo` ADD UNIQUE KEY `idx_bar` (`bar`)',
+					'utf8mb4' => null,
+				],
+				[
+					'checkQuery' => "SHOW INDEXES IN `#__foo` WHERE Key_name = 'idx_bar'",
+					'queryType' => 'ADD_INDEX',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_foo'", "'idx_bar'"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				[
+					'query' => 'ALTER TABLE `#__foo` ADD UNIQUE KEY `idx_bar`(`bar`)',
+					'utf8mb4' => null,
+				],
+				[
+					'checkQuery' => "SHOW INDEXES IN `#__foo` WHERE Key_name = 'idx_bar'",
+					'queryType' => 'ADD_INDEX',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_foo'", "'idx_bar'"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				[
+					'query' => "ALTER TABLE `#__foo` CHANGE `bar` `bar_new` mediumtext",
+					'utf8mb4' => false,
+				],
+				[
+					'checkQuery' => "SHOW COLUMNS IN `#__foo` WHERE field = 'bar_new' AND UPPER(type) = 'MEDIUMTEXT'",
+					'queryType' => 'CHANGE_COLUMN_TYPE',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_foo'", "'bar_new'", "mediumtext"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				[
+					'query' => "ALTER TABLE `#__foo` CHANGE `bar` `bar_new` mediumtext",
+					'utf8mb4' => true,
+				],
+				[
+					'checkQuery' => "SHOW COLUMNS IN `#__foo` WHERE field = 'bar_new' AND UPPER(type) IN ('MEDIUMTEXT','LONGTEXT')",
+					'queryType' => 'CHANGE_COLUMN_TYPE',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_foo'", "'bar_new'", "mediumtext"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				[
+					'query' => "ALTER TABLE `#__foo` CHANGE `bar` `bar_new` text",
+					'utf8mb4' => false,
+				],
+				[
+					'checkQuery' => "SHOW COLUMNS IN `#__foo` WHERE field = 'bar_new' AND UPPER(type) = 'TEXT'",
+					'queryType' => 'CHANGE_COLUMN_TYPE',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_foo'", "'bar_new'", "text"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				[
+					'query' => "ALTER TABLE `#__foo` CHANGE `bar` `bar_new` text",
+					'utf8mb4' => true,
+				],
+				[
+					'checkQuery' => "SHOW COLUMNS IN `#__foo` WHERE field = 'bar_new' AND UPPER(type) IN ('TEXT','MEDIUMTEXT')",
+					'queryType' => 'CHANGE_COLUMN_TYPE',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_foo'", "'bar_new'", "text"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				[
+					'query' => "ALTER TABLE `#__foo` CHANGE `bar` `bar_new` tinytext",
+					'utf8mb4' => false,
+				],
+				[
+					'checkQuery' => "SHOW COLUMNS IN `#__foo` WHERE field = 'bar_new' AND UPPER(type) = 'TINYTEXT'",
+					'queryType' => 'CHANGE_COLUMN_TYPE',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_foo'", "'bar_new'", "tinytext"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				[
+					'query' => "ALTER TABLE `#__foo` CHANGE `bar` `bar_new` tinytext",
+					'utf8mb4' => true,
+				],
+				[
+					'checkQuery' => "SHOW COLUMNS IN `#__foo` WHERE field = 'bar_new' AND UPPER(type) IN ('TINYTEXT','TEXT')",
+					'queryType' => 'CHANGE_COLUMN_TYPE',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_foo'", "'bar_new'", "tinytext"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				[
+					'query' => 'ALTER TABLE `#__foo` DROP COLUMN `bar`',
+					'utf8mb4' => null,
+				],
+				[
+					'checkQuery' => "SHOW COLUMNS IN `#__foo` WHERE Field = 'bar'",
+					'queryType' => 'DROP_COLUMN',
+					'checkQueryExpected' => 0,
+					'msgElements' => ["'jos_foo'", "'bar'"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				[
+					'query' => 'ALTER TABLE `#__foo` DROP INDEX `idx_bar`',
+					'utf8mb4' => null,
+				],
+				[
+					'checkQuery' => "SHOW INDEXES IN `#__foo` WHERE Key_name = 'idx_bar'",
+					'queryType' => 'DROP_INDEX',
+					'checkQueryExpected' => 0,
+					'msgElements' => ["'jos_foo'", "'idx_bar'"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				[
+					'query' => 'ALTER TABLE `#__foo` DROP KEY `idx_bar`',
+					'utf8mb4' => null,
+				],
+				[
+					'checkQuery' => "SHOW INDEXES IN `#__foo` WHERE Key_name = 'idx_bar'",
+					'queryType' => 'DROP_INDEX',
+					'checkQueryExpected' => 0,
+					'msgElements' => ["'jos_foo'", "'idx_bar'"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				[
+					'query' => "ALTER TABLE `#__foo` MODIFY `bar` mediumtext",
+					'utf8mb4' => false,
+				],
+				[
+					'checkQuery' => "SHOW COLUMNS IN `#__foo` WHERE field = 'bar' AND UPPER(type) = 'MEDIUMTEXT'",
+					'queryType' => 'CHANGE_COLUMN_TYPE',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_foo'", "'bar'", "mediumtext"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				[
+					'query' => "ALTER TABLE `#__foo` MODIFY `bar` mediumtext",
+					'utf8mb4' => true,
+				],
+				[
+					'checkQuery' => "SHOW COLUMNS IN `#__foo` WHERE field = 'bar' AND UPPER(type) IN ('MEDIUMTEXT','LONGTEXT')",
+					'queryType' => 'CHANGE_COLUMN_TYPE',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_foo'", "'bar'", "mediumtext"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				[
+					'query' => "ALTER TABLE `#__foo` MODIFY `bar` text",
+					'utf8mb4' => false,
+				],
+				[
+					'checkQuery' => "SHOW COLUMNS IN `#__foo` WHERE field = 'bar' AND UPPER(type) = 'TEXT'",
+					'queryType' => 'CHANGE_COLUMN_TYPE',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_foo'", "'bar'", "text"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				[
+					'query' => "ALTER TABLE `#__foo` MODIFY `bar` text",
+					'utf8mb4' => true,
+				],
+				[
+					'checkQuery' => "SHOW COLUMNS IN `#__foo` WHERE field = 'bar' AND UPPER(type) IN ('TEXT','MEDIUMTEXT')",
+					'queryType' => 'CHANGE_COLUMN_TYPE',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_foo'", "'bar'", "text"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				[
+					'query' => "ALTER TABLE `#__foo` MODIFY `bar` tinytext",
+					'utf8mb4' => false,
+				],
+				[
+					'checkQuery' => "SHOW COLUMNS IN `#__foo` WHERE field = 'bar' AND UPPER(type) = 'TINYTEXT'",
+					'queryType' => 'CHANGE_COLUMN_TYPE',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_foo'", "'bar'", "tinytext"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				[
+					'query' => "ALTER TABLE `#__foo` MODIFY `bar` tinytext",
+					'utf8mb4' => true,
+				],
+				[
+					'checkQuery' => "SHOW COLUMNS IN `#__foo` WHERE field = 'bar' AND UPPER(type) IN ('TINYTEXT','TEXT')",
+					'queryType' => 'CHANGE_COLUMN_TYPE',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_foo'", "'bar'", "tinytext"],
+					'checkStatus' => 0,
+				],
+			],
+			/*
+			 * The following "CREATE TABLE" statement is the shortest possible.
+			 * It is valid SQL, but currently the database schema check doesn't
+			 * understand it because it's shorter than expected.
+			 * This is a bug which has to be fixed, then this test has to be adapted
+			 * and this comment can be removed.
+			 */
+			[
+				[
+					'query' => 'CREATE TABLE `#__foo` (`bar` text)',
+					'utf8mb4' => null,
+				],
+				[
+					'checkQuery' => null,
+					'queryType' => null,
+					'checkQueryExpected' => 1,
+					'msgElements' => [],
+					'checkStatus' => -1,
+				],
+			],
+			[
+				[
+					'query' => 'CREATE TABLE IF NOT EXISTS `#__foo` (`bar` text)',
+					'utf8mb4' => null,
+				],
+				[
+					'checkQuery' => "SHOW TABLES LIKE 'jos_foo'",
+					'queryType' => 'CREATE_TABLE',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_foo'"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				[
+					'query' => 'RENAME TABLE `#__foo` TO `#__bar`',
+					'utf8mb4' => null,
+				],
+				[
+					'checkQuery' => "SHOW TABLES LIKE 'jos_bar'",
+					'queryType' => 'RENAME_TABLE',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_bar'"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				[
+					'query' => 'RENAME TABLE #__foo TO #__bar',
+					'utf8mb4' => null,
+				],
+				[
+					'checkQuery' => "SHOW TABLES LIKE 'jos_bar'",
+					'queryType' => 'RENAME_TABLE',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_bar'"],
+					'checkStatus' => 0,
+				],
+			],
+		];
+	}
+
+	/**
+	 * @param   array  $options  Options array to inject
+	 * @param   array  $expects  Expected data values
+	 *
+	 * @dataProvider constructData
+	 *
+	 * @return void
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testBuildCheckQuery($options, $expects)
+	{
+		$message = "Test '%s' for query '". $options['query'] . "'";
+		$utf8mb4 = $options['utf8mb4'] ?? true;
+
+		if (!$utf8mb4)
+		{
+			$message .= ' without utf8mb4 support';
+		}
+
+		$message .= ' failed.';
+
+		$this->db->expects($this->any())
+			->method('hasUTF8mb4Support')
+			->willReturn($utf8mb4);
+
+		$item = MysqlChangeItem::getInstance($this->db, '/not/really/used/4.0.0-2018-03-05.sql', $options['query']);
+
+		$this->assertEquals($expects['checkQuery'], $item->checkQuery, sprintf($message, 'checkQuery'));
+		$this->assertEquals($expects['queryType'], $item->queryType, sprintf($message, 'queryType'));
+		$this->assertEquals($expects['checkQueryExpected'], $item->checkQueryExpected, sprintf($message, 'checkQueryExpected'));
+		$this->assertEquals($expects['msgElements'], $item->msgElements, sprintf($message, 'msgElements'));
+		$this->assertEquals($expects['checkStatus'], $item->checkStatus, sprintf($message, 'checkStatus'));
+	}
+}

--- a/tests/Unit/Libraries/Cms/Schema/MysqlChangeItemTest.php
+++ b/tests/Unit/Libraries/Cms/Schema/MysqlChangeItemTest.php
@@ -10,8 +10,9 @@ namespace Joomla\Tests\Unit\Libraries\Cms\Schema;
 
 use Joomla\CMS\Schema\ChangeItem\MysqlChangeItem;
 use Joomla\Database\Mysqli\MysqliDriver;
+use Joomla\Tests\Unit\UnitTestCase;
 
-class MysqlChangeItemTest extends \PHPUnit\Framework\TestCase
+class MysqlChangeItemTest extends UnitTestCase
 {
 	/**
 	 * @var  MysqliDriver|MockObject

--- a/tests/Unit/Libraries/Cms/Schema/PostgresqlChangeItemTest.php
+++ b/tests/Unit/Libraries/Cms/Schema/PostgresqlChangeItemTest.php
@@ -137,12 +137,15 @@ class PostgresqlChangeItemTest extends UnitTestCase
 	}
 
 	/**
+	 * @testdox  A PostgresqlChangeItem instance is retreived with the right properties for the given SQL query
+	 *
+	 * @covers        Joomla\CMS\Schema\ChangeItem\PostgresqlChangeItem::getInstance
+	 * @dataProvider  constructData
+	 *
 	 * @param   array  $options  Options array to inject
 	 * @param   array  $expects  Expected data values
 	 *
-	 * @dataProvider constructData
-	 *
-	 * @return void
+	 * @return  void
 	 * @since   __DEPLOY_VERSION__
 	 */
 	public function testBuildCheckQuery($options, $expects)

--- a/tests/Unit/Libraries/Cms/Schema/PostgresqlChangeItemTest.php
+++ b/tests/Unit/Libraries/Cms/Schema/PostgresqlChangeItemTest.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Schema
+ *
+ * @copyright   (C) 2022 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+namespace Joomla\Tests\Unit\Libraries\Cms\Schema;
+
+use Joomla\CMS\Schema\ChangeItem\PostgresqlChangeItem;
+use Joomla\Database\DatabaseDriver;
+
+class PostgresqlChangeItemTest extends \PHPUnit\Framework\TestCase
+{
+	/**
+	 * @var  DatabaseDriver|MockObject
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected $db;
+
+	/**
+	 * Sets up the database mock.
+	 * This method is called before a test is executed.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function setUp():void
+	{
+		$this->db = $this->createMock(DatabaseDriver::class);
+
+		$this->db->expects($this->once())
+			->method('getServerType')
+			->willReturn('postgresql');
+
+		$this->db->expects($this->any())
+			->method('getPrefix')
+			->willReturn('jos_');
+
+		$this->db->expects($this->any())
+			->method('quote')->will(
+				$this->returnCallback(function ($arg) {
+					return "'" . $arg . "'";
+				})
+			);
+
+		$this->db->expects($this->any())
+			->method('quoteName')->will(
+				$this->returnCallback(function ($arg) {
+					return '"' . $arg . '"';
+				})
+			);
+	}
+
+	/**
+	 * Provides constructor data for test methods
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function constructData(): array
+	{
+		return [
+			[
+				['query' => 'WHATEVER'],
+				[
+					'checkQuery' => null,
+					'queryType' => null,
+					'checkQueryExpected' => 1,
+					'msgElements' => [],
+					'checkStatus' => -1,
+				],
+			],
+			[
+				['query' => 'ALTER TABLE "#__foo" ADD COLUMN "bar" text'],
+				[
+					'checkQuery' => "SELECT column_name FROM information_schema.columns WHERE table_name='jos_foo' AND column_name='bar'",
+					'queryType' => 'ADD_COLUMN',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_foo'", "'bar'"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				['query' => 'ALTER TABLE "#__foo" DROP COLUMN "bar"'],
+				[
+					'checkQuery' => "SELECT column_name FROM information_schema.columns WHERE table_name='jos_foo' AND column_name='bar'",
+					'queryType' => 'DROP_COLUMN',
+					'checkQueryExpected' => 0,
+					'msgElements' => ["'jos_foo'", "'bar'"],
+					'checkStatus' => 0,
+				],
+			],
+			[
+				['query' => 'ALTER TABLE "#__foo" RENAME TO "#__bar"'],
+				[
+					'checkQuery' => "SELECT table_name FROM information_schema.tables WHERE table_name='jos_bar'",
+					'queryType' => 'RENAME_TABLE',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_bar'"],
+					'checkStatus' => 0,
+				],
+			],
+			/*
+			 * The following "CREATE TABLE" statement is the shortest possible.
+			 * It is valid SQL, but currently the database schema check doesn't
+			 * understand it because it's shorter than expected.
+			 * This is a bug which has to be fixed, then this test has to be adapted
+			 * and this comment can be removed.
+			 */
+			[
+				['query' => 'CREATE TABLE "#__foo" ("bar" text)'],
+				[
+					'checkQuery' => null,
+					'queryType' => null,
+					'checkQueryExpected' => 1,
+					'msgElements' => [],
+					'checkStatus' => -1,
+				],
+			],
+			[
+				['query' => 'CREATE TABLE IF NOT EXISTS "#__foo" ("bar" text)'],
+				[
+					'checkQuery' => "SELECT table_name FROM information_schema.tables WHERE table_name='jos_foo'",
+					'queryType' => 'CREATE_TABLE',
+					'checkQueryExpected' => 1,
+					'msgElements' => ["'jos_foo'"],
+					'checkStatus' => 0,
+				],
+			],
+		];
+	}
+
+	/**
+	 * @param   array  $options  Options array to inject
+	 * @param   array  $expects  Expected data values
+	 *
+	 * @dataProvider constructData
+	 *
+	 * @return void
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testBuildCheckQuery($options, $expects)
+	{
+		$message = "Test '%s' for query '". $options['query'] . "' failed.";
+		$item    = PostgresqlChangeItem::getInstance($this->db, '/not/really/used/4.0.0-2018-03-05.sql', $options['query']);
+
+		$this->assertEquals($expects['checkQuery'], $item->checkQuery, sprintf($message, 'checkQuery'));
+		$this->assertEquals($expects['queryType'], $item->queryType, sprintf($message, 'queryType'));
+		$this->assertEquals($expects['checkQueryExpected'], $item->checkQueryExpected, sprintf($message, 'checkQueryExpected'));
+		$this->assertEquals($expects['msgElements'], $item->msgElements, sprintf($message, 'msgElements'));
+		$this->assertEquals($expects['checkStatus'], $item->checkStatus, sprintf($message, 'checkStatus'));
+	}
+}

--- a/tests/Unit/Libraries/Cms/Schema/PostgresqlChangeItemTest.php
+++ b/tests/Unit/Libraries/Cms/Schema/PostgresqlChangeItemTest.php
@@ -10,8 +10,9 @@ namespace Joomla\Tests\Unit\Libraries\Cms\Schema;
 
 use Joomla\CMS\Schema\ChangeItem\PostgresqlChangeItem;
 use Joomla\Database\DatabaseDriver;
+use Joomla\Tests\Unit\UnitTestCase;
 
-class PostgresqlChangeItemTest extends \PHPUnit\Framework\TestCase
+class PostgresqlChangeItemTest extends UnitTestCase
 {
 	/**
 	 * @var  DatabaseDriver|MockObject


### PR DESCRIPTION
This PR here is just for me for preparing my real PR to the CMS repo.

### Summary of Changes

- Migrated https://github.com/joomla/joomla-cms/blob/3.10-dev/tests/unit/suites/libraries/cms/schema/JSchemaChangeitemTest.php from J3 to https://github.com/richard67/joomla-cms/blob/4.2-dev-database-schema-changeitem-unit-tests/tests/Unit/Libraries/Cms/Schema/ChangeItemTest.php and simplified it by removing unused test parameters.
- Added new tests for the "buildCheckQuery" methods of the 2 subclasses "MysqlChangeItem" and "PostgresqlChangeItem". This allows to really test what the database checker does and is the base for testing future fixes and enhancements.

### Motivation for this PR

The database schema checker checks if the changes on data structure in update SQL scripts have been applied in the database or not, i.e. it does not check the complete schema, it only checks what has DDL (data definition language) statements in some update SQL script.

The syntax which is understood by the database checker is very limited. The checker does not understand every variant of valid SQL for a particular structure change.

In J3 the checker was only used for the core database tables and so it was a rarely changed piece of code. Core maintainers and contributors had to know about the limitations of the checker and had to write their update SQL scripts in a way so that the checker understands them.

In J4 the checker is also used to check tables of 3rd party components which have update SQL scripts. But the limitations of the checker are not described in any documentation. So the 3rd party developers don't know about that and write valid SQL for which the checker falsely reports database errors.

Therefore the database checker should be fixed for several kinds of SQL statements. But it is not really comfortable to prepare testing instructions for human tests for such future PRs.

The new unit tests for the "buildCheckQuery" methods will make it easier to test such future extensions. We can just use the unit tests to do that job. First one applies the changes unit tests of a future PR and see which tests fail, and then one applies the code changes in the change item classes to see that the tests which have failed before are passing now. This will make writing testing instructions as well as the human test much easier.

And the new test can serve as some kind of documentation on what queries the checker understands.

### Work in Progress

It needs to add more test cases to cover all relevant kinds of queries, e.g. the different adjustments for particular data types in queries which modify table columns.

In case of MySQL it also needs more test cases depending on utf8mb4 support, which is still necessary in case if the update from 3.10 to 4.2 runs on a database with data just having been migrated from am old database without utf8mb4 support so the utf8mb4 conversion takes places during the update, and so after the update data types might have changed so it still needs these tests. This can be removed with Joomla 5 from the database schema checker and the tests.

### To be Discussed

Currently the tests are more or less alphabetically ordered by the query to be checked. Maybe I should change that and add some comments to the data array so put things more logically together.

Maybe I also should change the reporting of the failed test results. Currently I report the query on test failure so it's easier to find out what failed, but the queries can be long, so maybe it would be even better if I would add some describing message to the test data array and report this on test failure. But this could increase the knowledge needed for maintaining these tests and so decrease maintainability.

### Testing Instructions

Will be added.

### Actual result BEFORE applying this Pull Request

Will be added.

### Expected result AFTER applying this Pull Request

Will be added.

### Documentation Changes Required

None.