### PR TITLE
Prevent displaying the post-installation message

### DIFF
--- a/administrator/components/com_admin/postinstall/htaccessbrotli.php
+++ b/administrator/components/com_admin/postinstall/htaccessbrotli.php
@@ -26,5 +26,11 @@
  */
 function admin_postinstall_htaccessbrotli_condition()
 {
-    return true;
+    $htaccessContent = '';
+
+    if (is_file(JPATH_ROOT . '/.htaccess') || is_file(JPATH_ROOT . '/htaccess.txt')) {
+        $htaccessContent = file_get_contents(is_file(JPATH_ROOT . '/.htaccess') ? JPATH_ROOT . '/.htaccess' : JPATH_ROOT . '/htaccess.txt');
+    }
+
+    return !str_contains($htaccessContent, 'E=no-brotli:1');
 }


### PR DESCRIPTION
Prevent displaying the post-installation message if Brotli support already integrated into the .htaccess file.
-> new installation of 4.4.4
