### PR TITLE
[CMS PR 45784] Update es-module-shims from 1.10.1 to 2.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "diff": "^5.2.0",
         "dotenv": "^17.2.1",
         "dragula": "^3.7.3",
-        "es-module-shims": "^1.10.1",
+        "es-module-shims": "^2.6.1",
         "focus-visible": "^5.2.1",
         "hotkeys-js": "^3.13.15",
         "joomla-ui-custom-elements": "^0.4.1",
@@ -5491,9 +5491,9 @@
       }
     },
     "node_modules/es-module-shims": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/es-module-shims/-/es-module-shims-1.10.1.tgz",
-      "integrity": "sha512-HSSkRLkqFEyX6GrCAHrSOR5iz/QzQJRqZUF7bFJOZ4aoSw0WoSggfsTIGN2yFbF8v6xjQFhT4HGP6b+0qQZmEQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/es-module-shims/-/es-module-shims-2.6.1.tgz",
+      "integrity": "sha512-ZdU6uF4Xka2i0ZnBT+gMt0KIaQb7yCIU0aTPk9gwgLzv3uhtHhCdcgfoQkFQzOZKSh5YJYgSBqAO0yDgRy9oig==",
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "diff": "^5.2.0",
     "dotenv": "^17.2.1",
     "dragula": "^3.7.3",
-    "es-module-shims": "^1.10.1",
+    "es-module-shims": "^2.6.1",
     "focus-visible": "^5.2.1",
     "hotkeys-js": "^3.13.15",
     "joomla-ui-custom-elements": "^0.4.1",


### PR DESCRIPTION
@dgrammatiko Do you think we can update the es-module-shims from 1.10.1 to 2.6.1?

When reading their release noted on https://github.com/guybedford/es-module-shims/releases I don't see any breaking changes.

But I might miss something.

The only place where I can see it being used in the core is `libraries/src/Document/Renderer/Html/ScriptsRenderer.php`.